### PR TITLE
fix: can't select `light` in `install.sh` UI dialog

### DIFF
--- a/core.sh
+++ b/core.sh
@@ -342,7 +342,7 @@ run_dialog() {
     tui=$(dialog --backtitle ${Project_Name} \
     --radiolist "Choose your Grub theme background color variant : " 15 40 5 \
       1 "Dark" on \
-      3 "Light" off --output-fd 1 )
+      2 "Light" off --output-fd 1 )
       case "$tui" in
         1) color="dark"       ;;
         2) color="light"      ;;


### PR DESCRIPTION
Currently, when directly executing `sudo ./install.sh` to enter the UI dialog, selecting `Light` in the step `Choose your Grub theme background color variant : ` causes the program to exit with the following message:

```
Operation canceled by user, Bye!
```

After investigation, it was found that the option index in `core.sh` for this step was incorrectly specified, which has now been fixed.
